### PR TITLE
FP3: proprietary-files: Extract PowerOffAlarm app

### DIFF
--- a/proprietary-files.txt
+++ b/proprietary-files.txt
@@ -1293,6 +1293,7 @@ vendor/etc/libnfc-qrd-NQ3XX.conf
 vendor/etc/libnfc-nci.conf
 
 #POWER_OFF_ALARM
+-app/PowerOffAlarm/PowerOffAlarm.apk
 vendor/bin/power_off_alarm
 vendor/lib64/hw/vendor.qti.hardware.alarm@1.0-impl.so
 vendor/lib64/vendor.qti.hardware.alarm@1.0.so


### PR DESCRIPTION
Required to make power off alarm work.